### PR TITLE
Update PK_WRF_compile_notes.sh

### DIFF
--- a/PK_WRF_compile_notes.sh
+++ b/PK_WRF_compile_notes.sh
@@ -20,3 +20,6 @@ cd ../WPS
 ./compile &> log.compile &
 tail -f log.compile
 
+## Note
+# For WRF compiled with SMPAR + DMPAR, WPS doesn't compile geogrid and metgrid
+# See report and fix in https://github.com/wrf-model/WPS/issues/110 (add `-fopenmp`)


### PR DESCRIPTION
@ClaireDons FYI

I tried compiling WRF with option 35 (DMPAR+SMPAR), then WPS failed to build geogrid and metgrid. A fix is available on github, here's a note to remember it for next time.